### PR TITLE
Added support for trajectories with vesicle states

### DIFF
--- a/js/src/custom-search.js
+++ b/js/src/custom-search.js
@@ -236,7 +236,6 @@ function createCustomSearchMenu() {
                     }
                 })
             });
-         //   console.log(summedConcentration);
             summedConcentrationValues.push(summedConcentration);
         });
         return summedConcentrationValues;

--- a/js/src/figures.js
+++ b/js/src/figures.js
@@ -23,12 +23,6 @@ const colorgrad = ['#008000', '#208600', '#318d00', '#409300',
 function showSvgCode() {
     let svgExport;
 
-    console.log($('#figure-file-name').val() + ".svg");
-
-
-    console.log($('input[name="fig"]:checked').val());
-
-
     if ($('input[name="fig"]:checked').val() === "spatial-view") {
         let temp = document.getElementById("trajectory-view-heatmap");
         svgExport = temp.getElementsByTagName("svg")[0];
@@ -51,7 +45,6 @@ function showSvgCode() {
 
     if ($('input[name="fig"]:checked').val() === "vesicle-track") {
 
-
         trackVesicleToSvg();
 
         let temp = document.getElementById("trajectory-view-graph");
@@ -68,9 +61,6 @@ function showSvgCode() {
 
 function exportSVG(svgExport) {
     let svgxml = (new XMLSerializer).serializeToString(svgExport);
-
-
-    console.log(svgxml);
 
     $("#svg_code").text(svgxml);
 
@@ -106,7 +96,6 @@ function trackVesicleToSvg() {
 
         counter++;
         currentcolor = colorgrad[counter];
-        console.log(counter);
         dragedTime = i;
 
         updateSpatialView(dragedTime, c, s, true);

--- a/js/src/heatmap-view.js
+++ b/js/src/heatmap-view.js
@@ -697,11 +697,7 @@ function drawSpatialView(selectedSpecies, figure) {
                     .style("stroke-width", "1");
                 mouseOverNode(this, nodeEntry, species, currentTimeStep);
                 showTooltip();
-                if (compartmentEntry.value.get("concentration") === undefined) {
-                    generateTooltip(nodeEntry.key + "<br/>" + compartmentEntry.key + "<br/>" + "value: " + "none");
-                } else {
-                    generateTooltip(nodeEntry.key + "<br/>" + compartmentEntry.key + "<br/>" + "value: " + compartmentEntry.value.get("concentration") + " " + concentrationUnit);
-                }
+                createTooltip("compartment", nodeEntry, compartmentEntry);
             })
             .on("mouseleave", function () {
                 d3.select(this)
@@ -712,7 +708,6 @@ function drawSpatialView(selectedSpecies, figure) {
                 hideTooltip();
             });
     }
-
 
     function drawVesicle(nodeEntry, figure) {
 
@@ -729,7 +724,6 @@ function drawSpatialView(selectedSpecies, figure) {
                     return currentcolor;
                 } else {
                     if (nodeEntry.value.get("vesicle membrane").get("concentration") !== undefined) {
-
                         return heatmapColor(nodeEntry.value.get("vesicle membrane").get("concentration"))
                     } else {
                         return "#fff"
@@ -763,18 +757,53 @@ function drawSpatialView(selectedSpecies, figure) {
             d3.select(this).style("stroke-width", "2px").style("stroke", "black");
             showTooltip();
             showTooltip();
-            if (nodeEntry.value.get("vesicle membrane").get("concentration") === undefined) {
-                generateTooltip(nodeEntry.key + "<br/>" + "<br/>" + "value: " + "none");
-            } else {
-                generateTooltip(nodeEntry.key + "<br/>" + "<br/>" + "value: " + nodeEntry.value.get("vesicle membrane").get("concentration") + " " + concentrationUnit);
-            }
-
+            createTooltip("vesicle", nodeEntry, null);
         }).on("mouseleave", function () {
             d3.select(this).style("stroke-width", "0").style("stroke", "unset");
             hideTooltip();
         })
 
+    }
 
+    function createTooltip(context, nodeEntry, compartmentEntry) {
+        // FIXME node entries are different depending on where the function is called
+        // FIXME it would be desirable to design uniform access to concentrations
+        switch (context) {
+            case "vesicle": {
+                createVesicleTooltipContent(nodeEntry);
+                break;
+            }
+            case "compartment": {
+                createCompartmentTooltipContent(nodeEntry, compartmentEntry);
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    function createCompartmentTooltipContent(nodeEntry, compartmentEntry) {
+        if (compartmentEntry.value.get("concentration") === undefined) {
+            generateTooltip(nodeEntry.key + "<br/>" +
+                compartmentEntry.key + "<br/>" +
+                "value: " + "none");
+        } else {
+            generateTooltip(nodeEntry.key + "<br/>" +
+                compartmentEntry.key + "<br/>" +
+                "value: " + compartmentEntry.value.get("concentration") + " " + concentrationUnit);
+        }
+    }
+
+    function createVesicleTooltipContent(nodeEntry) {
+        if (nodeEntry.value.get("vesicle membrane").get("concentration") === undefined) {
+            generateTooltip(nodeEntry.key + "<br/>" +
+                "state: " + vesicleStates.get(currentTimeStep).get(nodeEntry.key).replace("_", " ").toLowerCase() + "<br/>" +
+                "value: " + "none");
+        } else {
+            generateTooltip(nodeEntry.key + "<br/>" +
+                "state: " + vesicleStates.get(currentTimeStep).get(nodeEntry.key).replace("_", " ").toLowerCase()  + "<br/>" +
+                "value: " + nodeEntry.value.get("vesicle membrane").get("concentration") + " " + concentrationUnit);
+        }
     }
 
     function drawMembrane() {
@@ -815,11 +844,7 @@ function drawSpatialView(selectedSpecies, figure) {
                                 .style("stroke-width", "6px");
                             mouseOverNode(this, nodeEntry, species, currentTimeStep);
                             showTooltip();
-                            if (compartmentEntry.value.get("concentration") === undefined) {
-                                generateTooltip(nodeEntry.key + "<br/>" + compartmentEntry.key + "<br/>" + "value: " + "none");
-                            } else {
-                                generateTooltip(nodeEntry.key + "<br/>" + compartmentEntry.key + "<br/>" + "value: " + compartmentEntry.value.get("concentration") + " " + concentrationUnit);
-                            }
+                            createTooltip("compartment", nodeEntry, compartmentEntry);
                         })
                         .on("mouseleave", function () {
                             d3.select("#membrane" + i)

--- a/js/src/heatmap-view.js
+++ b/js/src/heatmap-view.js
@@ -779,27 +779,33 @@ function drawSpatialView(selectedSpecies, figure) {
     }
 
     function createCompartmentTooltipContent(nodeEntry, compartmentEntry) {
-        if (compartmentEntry.value.get("concentration") === undefined) {
-            generateTooltip(nodeEntry.key + "<br/>" +
-                compartmentEntry.key + "<br/>" +
-                "value: " + "none");
-        } else {
-            generateTooltip(nodeEntry.key + "<br/>" +
-                compartmentEntry.key + "<br/>" +
-                "value: " + compartmentEntry.value.get("concentration") + " " + concentrationUnit);
+        // determine concentration, if available
+        let vesicleMembraneConcentration = "none";
+        if (compartmentEntry.value.get("concentration") !== undefined) {
+            vesicleMembraneConcentration = compartmentEntry.value.get("concentration") + " " + concentrationUnit;
         }
+        // set tooltip
+        generateTooltip(nodeEntry.key + "<br/>" +
+            compartmentEntry.key + "<br/>" +
+            "value: " + vesicleMembraneConcentration);
+
     }
 
     function createVesicleTooltipContent(nodeEntry) {
-        if (nodeEntry.value.get("vesicle membrane").get("concentration") === undefined) {
-            generateTooltip(nodeEntry.key + "<br/>" +
-                "state: " + vesicleStates.get(currentTimeStep).get(nodeEntry.key).replace("_", " ").toLowerCase() + "<br/>" +
-                "value: " + "none");
-        } else {
-            generateTooltip(nodeEntry.key + "<br/>" +
-                "state: " + vesicleStates.get(currentTimeStep).get(nodeEntry.key).replace("_", " ").toLowerCase()  + "<br/>" +
-                "value: " + nodeEntry.value.get("vesicle membrane").get("concentration") + " " + concentrationUnit);
+        // determine state, if available
+        let vesicleState = "none";
+        if (vesicleStates.get(currentTimeStep).get(nodeEntry.key) !== undefined) {
+            vesicleState = vesicleStates.get(currentTimeStep).get(nodeEntry.key).replace("_", " ").toLowerCase()
         }
+        // determine concentration, if available
+        let vesicleMembraneConcentration = "none";
+        if (nodeEntry.value.get("vesicle membrane").get("concentration") !== undefined) {
+            vesicleMembraneConcentration = nodeEntry.value.get("vesicle membrane").get("concentration") + " " + concentrationUnit;
+        }
+        // set tooltip
+        generateTooltip(nodeEntry.key + "<br/>" +
+            "state: " + vesicleState + "<br/>" +
+            "value: " + vesicleMembraneConcentration);
     }
 
     function drawMembrane() {

--- a/js/src/heatmap-view.js
+++ b/js/src/heatmap-view.js
@@ -311,7 +311,6 @@ function drawSilder(species) {
                     timer = setInterval(function () {
                         step();
                     }, 100);
-                    //console.log(timer);
                     button.select("i").attr("class", "far fa-pause-circle fa-2x");
                     //button.text("Pause");
                 }
@@ -323,7 +322,6 @@ function drawSilder(species) {
 function step() {
     updateSpatialView(dragedTime, comp, spec);
     dragedTime = dragedTime + (5);
-    // console.log(dragedTime);
     if (dragedTime > time.length - 1) {
         moving = false;
         dragedTime = 0;
@@ -472,7 +470,6 @@ function getHeatmapData(species) {
                     compartmentMap.set("concentration", value.value);
                 }
                 if (value.key === "positions") {
-                    //  console.log(value.value);
                     if (updatable.key.startsWith("n")) {
                         if (compartment.key.includes("membrane")) {
 
@@ -495,7 +492,6 @@ function getHeatmapData(species) {
             })
         })
     });
-    console.log(heatmapData);
 }
 
 /**
@@ -952,7 +948,6 @@ function changeVerticalLineData(selectedTimeIdentifier) {
         d3.select(".trajectory.view.graph.verticalLine.valueLabel." + designator)
             .datum(data)
             .attr("transform", function (d) {
-                console.log(d);
                 return "translate(" + x(d.x) + "," + scales[number](d.y) + ")";
             }).text(function (d) {
             return d.y;

--- a/js/src/load-prepare-data.js
+++ b/js/src/load-prepare-data.js
@@ -186,7 +186,6 @@ function prepareNestedDataFromJson(data) {
                 }
 
                 if (currentKey === "state") {
-                    console.log(data[currentKey]);
                     vesicleStates.get(currentTime).set(currentNode, data[currentKey]);
                 }
 
@@ -273,7 +272,6 @@ function sumData() {
  */
 function sumCurrentNodeData() {
     reducedNodeData = [];
-    //console.log(nestedData);
     let combinationsofComponants = [];
 
     nestedData.keys().forEach(function (timeStep) {
@@ -294,7 +292,4 @@ function sumCurrentNodeData() {
             })
         }
     });
-
-console.log(reducedNodeData);
-
 }

--- a/js/src/load-prepare-data.js
+++ b/js/src/load-prepare-data.js
@@ -127,13 +127,15 @@ function prepareNestedDataFromJson(data) {
     for (let currentKey in data) {
 
         if (data[currentKey] !== null) {
+
             if (typeof (data[currentKey]) === "object") {
 
                 if (parent === "trajectory-data") {
                     currentTime = currentKey;
                     if (!time.includes(currentKey)) {
                         time.push(parseFloat(currentKey));
-                        nestedData.set(currentKey, d3.map())
+                        nestedData.set(currentKey, d3.map());
+                        vesicleStates.set(currentKey, d3.map());
                     }
                 }
 
@@ -181,6 +183,11 @@ function prepareNestedDataFromJson(data) {
 
                     }
 
+                }
+
+                if (currentKey === "state") {
+                    console.log(data[currentKey]);
+                    vesicleStates.get(currentTime).set(currentNode, data[currentKey]);
                 }
 
                 if (currentKey === "time-unit") {

--- a/js/src/singa.simulation.visualization.js
+++ b/js/src/singa.simulation.visualization.js
@@ -102,10 +102,7 @@ function getIndexIdentifier(selectedCompartment, selectedSpecies) {
  */
 function getCompartmentFromSpecies(species) {
     let compartment = [];
-    //console.log(componentCombinations);
     componentCombinations.forEach(function (currentTrajectory) {
-
-        //console.log(currentTrajectory);
         if (currentTrajectory.split("_")[1] === species) {
             compartment.push(currentTrajectory.split("_")[0]);
         }
@@ -171,7 +168,6 @@ function filterData(compartment, spec) {
     let trajectoryData = [];
     let obj = {};
 
-console.log(spec);
     nestedData.keys().forEach(function (element) {
 
         if (nestedData.get(element).get(selectedNode) === undefined) {

--- a/js/src/singa.simulation.visualization.js
+++ b/js/src/singa.simulation.visualization.js
@@ -15,6 +15,15 @@ let componentCombinations = [],
     concentrationUnit = null,
     reader = new FileReader(),
     globalData = null,
+
+    /**
+     * a nested map containing the vesicle states grouped by time step
+     *
+     * key: time step -> value:
+     *      ( key: vesicle -> value: state)
+     */
+    vesicleStates = d3.map(),
+
     heatmapSvg,
     searchButtonDataArray = [],
     heatmapData = d3.map(),

--- a/js/src/species-selection.js
+++ b/js/src/species-selection.js
@@ -78,7 +78,6 @@ function onSpeciesButtonClick(indexIdentifier, title) {
         d3.select('[id= "' + indexIdentifier + '"]').remove();
 
         //TODO auslagern
-console.log(indexIdentifier);
         d3.select("#selected_Button_area")
             .append("div")
             .style("margin-left","30px")


### PR DESCRIPTION
singa-simulation now also exports vesicle states per time step.

This PR implements reading states from trajectories as well as displaying them in vesicle tooltips.
The compatibility to trajectories without states is maintained.

Furthermore, I reduced some log pollution.